### PR TITLE
Replace deprecated include with import_playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you struggle with following the instructions for setting up the requirements 
 1. [VirtualBox](https://www.virtualbox.org/)
 2. [Vagrant](http://www.vagrantup.com/) (Known to work with 2.0.1 - 2.1.2)
 3. [git](https://git-scm.com/)
-4. [ansible](https://www.ansible.com/community) 2.3+
+4. [ansible](https://www.ansible.com/community) 2.4+
 5. [virtualbox-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin (If targeting CENTOS)
 
 ## Variables

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,12 +1,12 @@
 ---
 
-- include: bootstrap.yml
+- import_playbook: bootstrap.yml
   tags:
     - bootstrap
-- include: database.yml
-- include: solr.yml
-- include: webserver.yml
-- include: tomcat.yml
-- include: crayfish.yml
-- include: karaf.yml
-- include: post-install.yml
+- import_playbook: database.yml
+- import_playbook: solr.yml
+- import_playbook: webserver.yml
+- import_playbook: tomcat.yml
+- import_playbook: crayfish.yml
+- import_playbook: karaf.yml
+- import_playbook: post-install.yml


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#734

# What does this Pull Request do?

A start on fixing the deprecation warnings that are displayed when running Ansible 2.4.

This PR fixes the following deprecation warning:
```
[DEPRECATION WARNING]: 'include' for playbook includes. You should use 
'import_playbook' instead. This feature will be removed in version 2.8. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```