### PR TITLE
specify alpaca_karaf_repos to include 1.0.2 of alpaca

### DIFF
--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -4,6 +4,10 @@
  alpaca_from_source: yes
  alpaca_version: dev
  alpaca_clone_directory: /opt/alpaca
+ alpaca_karaf_repos:
+  - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
+  - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
+  - mvn:ca.islandora.alpaca/islandora-karaf/1.0.2/xml/features
 
  triplestore_namespace: islandora
  alpaca_triplestore_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host  }}:8080/bigdata"


### PR DESCRIPTION
# What does this Pull Request do?
Tells the ansible-role-alpaca to use version 1.0.2 of Alpaca

# What's new?
A change in the karaf.yml for inventory/vagrant/group_vars that overrides the defaults for ansible_karaf_repos in the ansible-role-alpaca

# How should this be tested?
* check out PR branch
* run clean install
* make a repository item
* check to make sure that repository item made it to fedora


# Interested parties
@Islandora-Devops/committers
