### PR TITLE
update drupal core via drupal-project

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -7,6 +7,7 @@ drupal_composer_dependencies:
   - "zaporylie/composer-drupal-optimizations:^1.0"
   - "drupal/console:~1.0"
   - "drupal/devel:^2.0"
+  - "drush/drush:^9.0"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
   - "drupal/search_api_solr:^2.0"

--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -18,7 +18,7 @@ drupal_composer_dependencies:
   - "drupal/rest_oai_pmh:^1.0"
   - "islandora/carapace:dev-8.x-3.x"
   - "islandora/islandora_defaults:dev-8.x-1.x"
-drupal_composer_project_package: "islandora/drupal-project:8.7"
+drupal_composer_project_package: "islandora/drupal-project:8.8.1"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
 drupal_db_user: drupal8

--- a/post-install.yml
+++ b/post-install.yml
@@ -11,10 +11,8 @@
   tasks:
 
     - name: Import feature
-      command:
-        cmd: "drupal features:import islandora_defaults"
-        chdir: "{{ drupal_composer_install_dir }}"
-      
+      command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim --bundle=islandora islandora_defaults"
+
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"
 
@@ -50,7 +48,7 @@
             append=yes
 
     - name: Create the default files simpletest directory
-      file: 
+      file:
         path: "{{ drupal_public_filesystem }}/simpletest"
         state: directory
         owner: "{{ webserver_app_user }}"
@@ -59,7 +57,7 @@
         recurse: yes
 
     - name: Create the sites simpletest directory
-      file: 
+      file:
         path: "{{ drupal_core_path }}/sites/simpletest"
         state: directory
         owner: "{{ webserver_app_user }}"

--- a/post-install.yml
+++ b/post-install.yml
@@ -11,7 +11,9 @@
   tasks:
 
     - name: Import feature
-      command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim --bundle=islandora islandora_defaults"
+      command:
+        cmd: "drupal features:import islandora_defaults"
+        chdir: "{{ drupal_composer_install_dir }}"
       
     - name: Add admin to fedoraAdmin role
       command: "{{ drush_path }} --root {{ drupal_core_path }} -y urol fedoraadmin admin"

--- a/roles/internal/perms-fix/tasks/main.yml
+++ b/roles/internal/perms-fix/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+  - name: Edit permissions for default.services.yml
+    file:
+      state: directory
+      path: "{{ drupal_core_path }}/sites/default"
+      owner: "{% if ansible_os_family == 'RedHat' %}vagrant{% else %}ubuntu{% endif %}"
+      group: "{% if ansible_os_family == 'RedHat' %}vagrant{% else %}ubuntu{% endif %}"
+      mode: '1777'

--- a/roles/internal/perms-fix/tasks/main.yml
+++ b/roles/internal/perms-fix/tasks/main.yml
@@ -3,6 +3,6 @@
     file:
       state: directory
       path: "{{ drupal_core_path }}/sites/default"
-      owner: "{% if ansible_os_family == 'RedHat' %}vagrant{% else %}ubuntu{% endif %}"
-      group: "{% if ansible_os_family == 'RedHat' %}vagrant{% else %}ubuntu{% endif %}"
+      owner: "{{ webserver_app_user }}"
+      group: "{{ webserver_app_user }}"
       mode: '1777'

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -60,9 +60,8 @@
     group: "{{ webserver_app_user }}"
 
 - name: Import features
-  command:
-    cmd: "drupal features:import islandora_core_feature controlled_access_terms_defaults"
-    chdir: "{{ drupal_composer_install_dir }}"
+  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_defaults"
+
 
 # masonry library is required by content_browser and not installed by composer due to issue 2971165.
 - name: Create drupal library directory.

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -60,7 +60,9 @@
     group: "{{ webserver_app_user }}"
 
 - name: Import features
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y fim islandora_core_feature,controlled_access_terms_defaults"
+  command:
+    cmd: "drupal features:import islandora_core_feature controlled_access_terms_defaults"
+    chdir: "{{ drupal_composer_install_dir }}"
 
 # masonry library is required by content_browser and not installed by composer due to issue 2971165.
 - name: Create drupal library directory.

--- a/webserver.yml
+++ b/webserver.yml
@@ -18,6 +18,7 @@
     - geerlingguy.drush
     - geerlingguy.drupal-console
     - geerlingguy.drupal
+    - perms-fix
     - Islandora-Devops.drupal-openseadragon
     - webserver-app
     - Islandora-Devops.matomo

--- a/webserver.yml
+++ b/webserver.yml
@@ -6,6 +6,9 @@
   vars:
     php_version: "7.2"
 
+  environment:
+    COMPOSER_MEMORY_LIMIT: -1
+
   roles:
     - name: geerlingguy.repo-remi
       when: ansible_os_family == "RedHat"


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1387)

# What does this Pull Request do?

Points the playbook to the new release of the drupal project which ships with drupal core 8.8.1

# What's new?
* changes release version of drupal-project

# How should this be tested?

* clone playbook
* vagrant up
* make sure drupal 8.8.1 is installed



# Interested parties
@Islandora-Devops/committers
