### PR TITLE
point blazegraph ansible role to master

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -93,7 +93,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster

--- a/requirements.yml
+++ b/requirements.yml
@@ -57,7 +57,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: 1.0.1
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe


### PR DESCRIPTION
**GitHub Issue**: None

https://islandora.slack.com/archives/CM5PPAV28/p1579194273194600

# What does this Pull Request do?

Updates the role references in requirements.yml to account for Maven's https requirement.

# What's new?

* Changes blazegraph and karaf version requirements to 'master'.

# How should this be tested?

* Clone a fresh playbook (`vagrant up` will die on blazegraph).
* apply the PR
* Clear external roles `rm -rf roles/external/*`
* `vagrant up --provision`
* Build completes successfully.

# Additional Notes:

We can cut versions when we do the Islandora 8.x-1.1.0 release.

# Interested parties
@Islandora-Devops/committers, @dbernstein, @ajstanley
