### PR TITLE
Set Islandora-Devops ansible roles to use 'master' versions in dev

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -45,7 +45,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-activemq
   name: Islandora-Devops.activemq
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-alpaca
   name: Islandora-Devops.alpaca
@@ -61,27 +61,27 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-crayfish
   name: Islandora-Devops.crayfish
-  version: 1.0.3
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-drupal-openseadragon
   name: Islandora-Devops.drupal-openseadragon
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo
   name: Islandora-Devops.fcrepo
-  version: 2.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-fcrepo-syn
   name: Islandora-Devops.fcrepo-syn
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-tomcat8
   name: Islandora-Devops.tomcat8
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-fits
   name: Islandora-Devops.fits
@@ -89,7 +89,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-grok
   name: Islandora-Devops.grok
-  version: 2.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf
@@ -97,8 +97,8 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-matomo
   name: Islandora-Devops.matomo
-  version: 1.0.0
+  version: master

--- a/requirements.yml
+++ b/requirements.yml
@@ -93,7 +93,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-karaf
   name: Islandora-Devops.karaf
-  version: 1.0.0
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-keymaster
   name: Islandora-Devops.keymaster

--- a/requirements.yml
+++ b/requirements.yml
@@ -57,7 +57,7 @@
 
 - src: https://github.com/Islandora-Devops/ansible-role-blazegraph
   name: Islandora-Devops.blazegraph
-  version: 1.0.1
+  version: master
 
 - src: https://github.com/Islandora-Devops/ansible-role-cantaloupe
   name: Islandora-Devops.cantaloupe


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1404

Follow on to #150

# What does this Pull Request do?

Moves all the Islandora-Devops ansible roles to 'master' on the dev branch so we don't have to worry about pegging versions until release time.

# How should this be tested?

Clone the PR and `vagrant up` = successful playbook.

# Interested parties
@dannylamb 
