### PR TITLE
update search_api_solr to 3.8

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -10,7 +10,7 @@ drupal_composer_dependencies:
   - "drush/drush:^9.0"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
-  - "drupal/search_api_solr:^2.0"
+  - "drupal/search_api_solr:^3.8"
   - "drupal/facets:^1.3"
   - "drupal/content_browser:^1.0@alpha"
   - "drupal/matomo:^1.7"

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,8 +4,8 @@
   tags:
     - bootstrap
 - import_playbook: database.yml
-- import_playbook: solr.yml
 - import_playbook: webserver.yml
+- import_playbook: solr.yml
 - import_playbook: tomcat.yml
 - import_playbook: crayfish.yml
 - import_playbook: karaf.yml

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -7,7 +7,7 @@
   composer:
     command: require
     arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' drupal/search_api_solr
-    working_dir: "/var/www/html/drupal"
+    working_dir: "{{ drupal_composer_install_dir }}"
 
 - name: Set default solr server host from hostvars
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.host {{ hostvars[groups['solr'][0]].ansible_host  }}"

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -6,7 +6,7 @@
 - name: Add a patch for symfony-event-dispatcher per the INSTALL.md docs on search_api_solr:3.8
   composer:
     command: require
-    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' solarium/solarium:^5.1.4 drupal/search_api_solr
+    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' solarium/solarium:^5.1 drupal/search_api_solr
     working_dir: "{{ drupal_composer_install_dir }}"
 
 - name: Set default solr server host from hostvars

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -3,6 +3,11 @@
 
 # Only tasks related to configuring search_api_solr are put here
 # Solr server configuration should go into the solr playbook: https://github.com/Islandora-Devops/claw-playbook/blob/dev/solr.yml
+- name: Add a patch for symfony-event-dispatcher per the INSTALL.md docs on search_api_solr:3.8
+  composer:
+    command: require
+    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' drupal/search_api_solr
+    working_dir: "/var/www/html/drupal"
 
 - name: Set default solr server host from hostvars
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.host {{ hostvars[groups['solr'][0]].ansible_host  }}"
@@ -13,4 +18,9 @@
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.core {{ solr_cores[0] }}"
   register: set_search_api_config_core
   changed_when: "'Do you want to update' in set_search_api_config.stdout"
+
+- name: Create SOLR config.zip
+  command:
+    cmd: "{{ drush_path }} --root {{ drupal_core_path }} -y solr-gsc default_solr_server solr_config.zip 7.1"
+    chdir: "{{ drupal_core_path }}"
 

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -6,7 +6,7 @@
 - name: Add a patch for symfony-event-dispatcher per the INSTALL.md docs on search_api_solr:3.8
   composer:
     command: require
-    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' drupal/search_api_solr
+    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' solarium/solarium:^5.1.4 drupal/search_api_solr
     working_dir: "{{ drupal_composer_install_dir }}"
 
 - name: Set default solr server host from hostvars

--- a/solr.yml
+++ b/solr.yml
@@ -25,7 +25,7 @@
 
     - name: Unarchive solr config
       unarchive:
-        src: http://localhost:8000/solr_config.zip
+        src: http://{{ hostvars[groups['webserver'][0]].ansible_host }}:{{ apache_listen_port }}/solr_config.zip
         dest: /tmp/solr_config
         remote_src: yes
       tags: solr
@@ -61,7 +61,7 @@
 
     - name: Fetch a Solr query to warm up the application
       uri:
-        url: http://localhost:8983/solr/{{ solr_cores[0] }}/select?q=warm
+        url: http://{{ hostvars[groups['solr'][0]].ansible_host  }}:8983/solr/{{ solr_cores[0] }}/select?q=warm
         method: GET
         return_content: yes
         status_code: [200,412]

--- a/solr.yml
+++ b/solr.yml
@@ -16,18 +16,22 @@
     - geerlingguy.solr
 
   tasks:
+
+    - name: Make tmp dir for solr config
+      file:
+        path: /tmp/solr_config
+        state: directory
+      tags: solr
+
     - name: Unarchive solr config
       unarchive:
-        src: "https://ftp.drupal.org/files/projects/search_api_solr-8.x-2.0.zip"
-        dest: /tmp
+        src: http://localhost:8000/solr_config.zip
+        dest: /tmp/solr_config
         remote_src: yes
-      register: solr_config_download_and_extract
-      until: solr_config_download_and_extract is not failed
-      retries: 5
       tags: solr
 
     - name: Get solr config files to copy
-      command: "find /tmp/search_api_solr/solr-conf/7.x -type f"
+      command: "find /tmp/solr_config -type f"
       register: files_to_copy
       changed_when: false
       until: files_to_copy is not failed
@@ -57,7 +61,7 @@
 
     - name: Fetch a Solr query to warm up the application
       uri:
-        url: http://localhost:8983/solr/ISLANDORA/select?q=warm
+        url: http://localhost:8983/solr/{{ solr_cores[0] }}/select?q=warm
         method: GET
         return_content: yes
         status_code: [200,412]


### PR DESCRIPTION
# What does this Pull Request do?

Updates search_api_solr to version 3.8

# What's new?
* Updates [search_api_solr](https://www.drupal.org/project/search_api_solr) to version 3.8
* Per the [install.md](https://git.drupalcode.org/project/search_api_solr/blob/8.x-3.x/INSTALL.md) - adds a patch for Drupal Core
* Per the [install.md](https://git.drupalcode.org/project/search_api_solr/blob/8.x-3.x/INSTALL.md) - uses drush command to generate the default solr config files
* Reorders the playbook.yml so that solr.yml runs after webserver.yml because the solr config setup requires the output of the drush command

# How should this be tested?

* check out this PR, vagrant up
* check to see that you got a running solr instance with a core called ISLANDORA
* check to see that you have a default solr server in the drupal search api config (http://localhost:8000/admin/config/search/search-api/)
* check that http://localhost:8000/admin/config/search/search-api/server/default_solr_server says the schema is set to drupal-8.3.8-solr-7.x
* check that you can create an object and that it is indexed in solr and searchable

# Additional Notes:
I was concerned about conflating the solr host and the webserver host so that is why I implemented the "Unarchive solr config" as a request to localhost instead of directly from a file path like `/var/www/...` 

# Interested parties
@Islandora-Devops/committers
