### PR TITLE
Removes references to logging into VM with the user 'ubuntu'

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,6 @@ You can access the Solr administration UI at http://localhost:8983/solr/
 You can connect to the machine via ssh:
 
   * `vagrant ssh`
-  * `ssh -p 2222 ubuntu@localhost`
-
-### VM
-
-The default VM login details are:
-  
-  * username: ubuntu
-  * password: ubuntu
   
 ### ActiveMQ
 


### PR DESCRIPTION

# What does this Pull Request do?
This PR only changes the README.md. It's a minimal change just removing the login option of user 'ubuntu' as that doesn't function anymore. There is a user 'ubuntu', but you'd have to setup an SSH key to log in that way.  

Right now, since you can't ssh in as 'ubuntu' with a password, it's good to remove this from the readme. 

* Deletes a few lines talking about login for user 'ubuntu'

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
