### PR TITLE
Changes vagrantUser to vagrant for all installs.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "I
 # Available boxes are 'ubuntu/xenial64' and 'centos/7'
 $vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "ubuntu/bionic64")
 
-# On Ubuntu, user is ubuntu, on all others, user is vagrant
-$vagrantUser = if $vagrantBox == "ubuntu/bionic64" then "ubuntu" else "vagrant" end
+# vagrant is the main user
+$vagrantUser = "vagrant"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|

--- a/post-install.yml
+++ b/post-install.yml
@@ -6,7 +6,7 @@
   # add some vars here so we can run with --start-at-task if desired
   vars:
     webserver_app_user: "{% if ansible_os_family == 'RedHat' %}apache{% else %}www-data{% endif %}"
-    vagrant_user: "{% if ansible_os_family == 'RedHat' %}vagrant{% else %}ubuntu{% endif %}"
+    vagrant_user: "vagrant"
 
   tasks:
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1431
# What does this Pull Request do?
This pull requests makes `vagrant` the main user in all VMs.  This change mainly affects those using Ubuntu, as `ubuntu` was the vagrantUser before. 

For Ubuntu users (the default OS), this change causes the islandora-playbook directory (named `islandora`) to appear in `vagrant`'s home directory.  As one cannot log in as the `ubuntu` user, this makes more sense to have `vagrant` as main user. 

# What's new?
* For all VM's this changes the `vagrantUser` to `vagrant` - especially effects Ubuntu users, as those using CentOS already had `vagrant` as main user.

* Could this change impact execution of existing code?
Yes, but minimally....?  Not sure if there is a ripple effect.  

# How should this be tested?
* I think you need a fresh VM (not 100% sure on that, but it's what I tried). 
* `vagrant up`
* `vagrant ssh`

You should now be logged in as`vagrant` and see a directory named `islandora` in the home directory. 

# Interested parties
 (@dannylamb )  @Islandora-Devops/committers
