### PR TITLE
Enabling/disabling syn with separate provisioners

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,4 +61,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.extra_vars = { "islandora_distro" => $vagrantBox }
   end
 
+  config.vm.provision "disable-syn", type: "shell", run: "never" do |s|
+    s.inline = "/bin/bash /home/vagrant/islandora/config-syn.sh disable; service tomcat8 restart"
+  end
+
+  config.vm.provision "enable-syn", type: "shell", run: "never" do |s|
+    s.inline = "/bin/bash /home/vagrant/islandora/config-syn.sh enable; service tomcat8 restart"
+  end
 end

--- a/config-syn.sh
+++ b/config-syn.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# 
+# Simple script to enable or disable the Syn Valve for manipulating 
+# Fedora directly w/in the Islandora 8 project.
+#
+# usage:  ./config-syn.sh enable|disable
+#     enable turns the valve on, disabling direct write access to Fedora
+#     disable turns the valve off, enabling direct write access to Fedora. 
+#
+# The first time disable is run, it will inject a few lines of code
+# to add a user to fedora and also put in the framework to disable the valve. 
+#
+# author: bseeger
+# since: Feb 2020
+
+TOMCAT_USERS_FILE=/var/lib/tomcat8/conf/tomcat-users.xml
+SYN_SETTINGS_FILE=/var/lib/tomcat8/conf/syn-settings.xml
+#TOMCAT_USERS_FILE=./tomcat-users.xml    # for testing
+#SYN_SETTINGS_FILE=./syn-settings.xml    # for testing
+ISLANDORA_USER='<user username="islandora" password="islandora" roles="manager-gui"\/>'
+FEDORA_USER='<user username="fedoraAdmin" password="secret3" roles="fedoraAdmin"\/>'
+# these two users are used to demonstrate WebACLs in part of the workshop
+TEST_USER='<user username="testuser" password="password1" roles="fedoraUser"\/>'
+ADMIN_USER='<user username="adminuser" password="password2" roles="fedoraUser"\/>'
+
+failed=0
+if [ -z $1 ]; then
+    echo 'Usage:  config-syn.sh [enable | disable]'
+    exit 0
+fi
+
+##### Part 1: Add 'fedoraAdmin' user to the tomcat-users.xml file
+
+# is the user in the file already? 
+resp=`sed '/fedoraAdmin/,$p' $TOMCAT_USERS_FILE -n`
+
+if [ -z "$resp" ]; then
+    # add it
+    `sed -i -e "s/$ISLANDORA_USER/$ISLANDORA_USER\n        $FEDORA_USER\n        $TEST_USER\n        $ADMIN_USER/g" $TOMCAT_USERS_FILE`
+    echo 'Added user to tomcat-users.xml file.  User: fedoraAdmin  pass: secret3'
+
+else
+    echo $resp
+fi
+
+##### Part 2: Enable or disable the valve, depending on input
+
+# normalize input to lower case
+mode=`echo $1 | tr '[:upper:]' '[:lower:]'`
+
+if [ "$mode" == "enable" ]; then
+    `sed -i -e "s/^<config version='1' header='X-Islandora'.*>$/<config version='1' header='X-Islandora' disabled='false'>/g" $SYN_SETTINGS_FILE`
+    echo "Syn valve enabled."
+elif [ "$mode" == "disable" ]; then
+    `sed -i -e "s/^<config version='1' header='X-Islandora'.*>$/<config version='1' header='X-Islandora' disabled='true'>/g" $SYN_SETTINGS_FILE`
+    echo "Syn valve disabled."
+else
+    failed=1
+    echo "Invalid option '$1' entered, valve not changed."
+fi
+
+if [ "$failed" -ne 1 ]; then
+    echo "Now restart tomcat with: 'sudo service tomcat8 restart'"
+fi
+
+


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1431

# What does this Pull Request do?

Lets you disable Syn for fcrepo on Vagrant builds.  Its for demos and such.

# What's new?

Two new shell provisioners, for disabling and enabling syn.  This uses @bseeger's script here: https://gist.githubusercontent.com/bseeger/90c80d8f71e17ad4283765b2f88afaed/raw/55c82df5200b3a0c62af63d4f4d9845efce161b7/config-syn.sh

# How should this be tested?

The provisioners never run unless explictly told to do so.  So once you've `vagrant up'd` successfully, confirm that you can't create a container or upload a file through the Web UI at `http://localhost:8080/fcrepo/rest`. Then run `vagrant provision --provision-with disable-syn`.  This will disable Syn and restart Tomcat.  You can confirm it works by creating a container or uploading a file through Fedora's UI.

# Interested parties
@bseeger @dwilcox @Islandora-Devops/committers
