### PR TITLE
Set Grok version based on distro

### DIFF
--- a/inventory/vagrant/group_vars/tomcat.yml
+++ b/inventory/vagrant/group_vars/tomcat.yml
@@ -56,8 +56,6 @@ fcrepo_version: "5.1.0"
 fcrepo_auth_header_name: "X-Islandora"
 fcrepo_syn_auth_header: "X-Islandora"
 
-grok_version_tag: v3.1.0
-
 cantaloupe_deploy_war: yes
 cantaloupe_deploy_war_path: "{{ tomcat8_home }}/webapps"
 cantaloupe_user: tomcat8

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,7 @@
 ---
 
+grok_version_tag: v3.1.0
+
 php_packages_extra:
   - libapache2-mod-php7.2
   - php7.2-mysql

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,7 @@
 ---
 
+grok_version_tag: v2.3.0
+
 php_packages_extra:
   - php-mysql
   - php-pgsql


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1453

See also [today's tech call](https://github.com/Islandora/documentation/wiki/March-11%2C-2020).

# What does this Pull Request do?

Moves the grok version variable to the appropriate vars files and sets versions accordingly.

# What's new?

* Changes Grok version to 3.x for Debian and 2.x for CentOS.

# How should this be tested?

- Vagrant up using Ubuntu and everything is happy.
- Vagrant up using CentOS and everything is happy.

# Interested parties
@Islandora-Devops/committers
