### PR TITLE
Update geerlingguy versions

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,10 +11,10 @@
   version: 3.0.0
 
 - src: geerlingguy.php-versions
-  version: 2.1.5
+  version: 4.0.0
 
 - src: geerlingguy.php
-  version: 3.6.0
+  version: 4.0.0
 
 - src: geerlingguy.composer
   version: 1.7.0
@@ -23,7 +23,7 @@
   version: 2.0.2
 
 - src: geerlingguy.mysql
-  version: 2.9.0
+  version: 3.1.0
 
 - src: geerlingguy.postgresql
   version: 1.4.3


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1343
The build fails to build. Looks like a version problem.

# What does this Pull Request do?
Updates 3 roles geerlingguy.php, geerlingguy.php-versions, geerlingguy.mysql

# What's new?
geerlingguy.php -> v4.0.0
geerlingguy.php-versions -> v4.0.0
geerlingguy.mysql -. v3.1.0

# How should this be tested?
### Remove external roles, build and get a fail
```shell
$ vagrant destroy -f
$ rm -rf roles/external/*
$ vagrant up
```

### Remove external roles, switch to this PR, build again and it will pass
```shell
$ vagrant destroy -f
$ rm -rf roles/external/*
# switch to this PR
$ vagrant up
```

# Additional Notes:
N/A

# Interested parties
@Islandora-Devops/committers
