### PR TITLE
Use roles/external as the default location for ansible-galaxy install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.compatibility_mode = "auto"
     ansible.playbook = "playbook.yml"
     ansible.galaxy_role_file = "requirements.yml"
-    ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file} --roles-path=roles/external"
+    ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
     ansible.limit = "all"
     ansible.inventory_path = "inventory/vagrant"
     ansible.host_vars = {

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,7 +3,7 @@
 
 [defaults]
 host_key_checking = false
-roles_path = roles/internal:roles/external
+roles_path = roles/external:roles/internal
 callback_whitelist = profile_tasks
 fact_caching = jsonfile
 fact_caching_connection = /tmp/.ansible_fact_cache


### PR DESCRIPTION
# What does this Pull Request do?

If a user executes the following command:

```
ansible-galaxy install -r requirements.xml
```

The roles will be installed into **roles/internal**, since no specific path has been specified and the first path listed in the configuration is **roles/internal**. 

This pull request changes this behaviour such that the default location it will install roles into is **roles/external**. This is useful for those who want to use the Ansible roles but do not with to use it via Vagrant (which specified the **roles/external** path explicitly).

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Default location of roles installation changed to **roles/external** rather than **roles/internal**

# How should this be tested?

Execute the command:

```
ansible-galaxy install -r requirements.xml
```

Note that the roles are installed in the correct location without the need of also giving the explicit path.

# Interested parties
@Islandora-Devops/committers
