### PR TITLE
Pull latest karaf version

### DIFF
--- a/inventory/vagrant/group_vars/karaf.yml
+++ b/inventory/vagrant/group_vars/karaf.yml
@@ -7,7 +7,7 @@
  alpaca_karaf_repos:
   - mvn:org.apache.camel.karaf/apache-camel/2.20.4/xml/features
   - mvn:org.apache.activemq/activemq-karaf/5.15.0/xml/features
-  - mvn:ca.islandora.alpaca/islandora-karaf/1.0.2/xml/features
+  - mvn:ca.islandora.alpaca/islandora-karaf/LATEST/xml/features
 
  triplestore_namespace: islandora
  alpaca_triplestore_base_url: "http://{{ hostvars[groups['tomcat'][0]].ansible_host  }}:8080/bigdata"


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Makes the dev branch pull the most recent version from maven, which is overridden anyways because we build it from source.

At a release we probably don't want to build from source and instead pin this variable to a specific maven version of Alpaca.

# How should this be tested?

1. Build the islandora-playbook
1. Then go into the vm `vagrant ssh`
1. Goto `cd /opt/maven/repo/ca/islandora/alpaca/`
1. In all of the subdirectories you should have a `1.0.3` directory.

# Interested parties
@Islandora-Devops/committers
