### PR TITLE
Use islandora/8 to pull a fully built box from vagrant cloud

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--cpus", $cpus]
     vb.customize ["modifyvm", :id, "--description", $virtualBoxDescription]
     vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "disconnected" ]
   end
 
   if $vagrantBox != "islandora/8" then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,10 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "4096")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora8")
 $virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "Islandora 8")
 
-# Available boxes are 'ubuntu/xenial64' and 'centos/7'
-$vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "ubuntu/bionic64")
+# Available boxes are 'islandora/8', ubuntu/bionic64' and 'centos/7'
+# Use 'ubuntu/bionic64' or 'centos/7' to build a dev environment from scratch.
+# Use 'islandora/8' if you just want to download a ready to run VM.
+$vagrantBox = ENV.fetch("ISLANDORA_DISTRO", "islandora/8")
 
 # vagrant is the main user
 $vagrantUser = "vagrant"
@@ -48,17 +50,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--audio", "none"]
   end
 
-  config.vm.provision :ansible do |ansible|
-    ansible.compatibility_mode = "auto"
-    ansible.playbook = "playbook.yml"
-    ansible.galaxy_role_file = "requirements.yml"
-    ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
-    ansible.limit = "all"
-    ansible.inventory_path = "inventory/vagrant"
-    ansible.host_vars = {
-      "all" => { "ansible_ssh_user" => $vagrantUser }
-    }
-    ansible.extra_vars = { "islandora_distro" => $vagrantBox }
+  if $vagrantBox != "islandora/8" then
+    config.vm.provision :ansible do |ansible|
+      ansible.compatibility_mode = "auto"
+      ansible.playbook = "playbook.yml"
+      ansible.galaxy_role_file = "requirements.yml"
+      ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
+      ansible.limit = "all"
+      ansible.inventory_path = "inventory/vagrant"
+      ansible.host_vars = {
+        "all" => { "ansible_ssh_user" => $vagrantUser }
+      }
+      ansible.extra_vars = { "islandora_distro" => $vagrantBox }
+    end
   end
 
 end


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1494

# What does this Pull Request do?

I'm uploading a box to vagrant cloud as `islandora/8`.  This PR points to this box by default, so that when people hit `vagrant up`, it will download a fully built box and "just work", as opposed to try and provision with ansible.  If you decare the `islandora_distro` variable to be either `centos/7` or `ubuntu/bionic64`, you'll get the usual dev build.

# How should this be tested?

I'll comment on this issue when the upload to vagrant cloud has finished.  Once that's done, pull in this PR and `vagrant up`.  Vagrant should download the `islandora/8` box and boot up, without provisioning.

Make sure you can `vagrant ssh` into the box and give it a whirl.

It's the 1.1.0 build, FYI.

# Interested parties
@DonRichards @wgillingham @Islandora-Devops/committers
