### PR TITLE
#1545 Update Search API Solr to 8.x-4.1

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -10,7 +10,7 @@ drupal_composer_dependencies:
   - "drush/drush:^9.0"
   - "drupal/rdfui:^1.0-beta1"
   - "drupal/restui:^1.16"
-  - "drupal/search_api_solr:^3.8"
+  - "drupal/search_api_solr:^4.1"
   - "drupal/facets:^1.3"
   - "drupal/content_browser:^1.0@alpha"
   - "drupal/matomo:^1.7"

--- a/roles/internal/webserver-app/tasks/solr.yml
+++ b/roles/internal/webserver-app/tasks/solr.yml
@@ -3,12 +3,6 @@
 
 # Only tasks related to configuring search_api_solr are put here
 # Solr server configuration should go into the solr playbook: https://github.com/Islandora-Devops/claw-playbook/blob/dev/solr.yml
-- name: Add a patch for symfony-event-dispatcher per the INSTALL.md docs on search_api_solr:3.8
-  composer:
-    command: require
-    arguments: symfony/event-dispatcher:'4.3.4 as 3.4.99' solarium/solarium:^5.1 drupal/search_api_solr
-    working_dir: "{{ drupal_composer_install_dir }}"
-
 - name: Set default solr server host from hostvars
   command: "{{ drush_path }} --root {{ drupal_core_path }} -y config-set search_api.server.default_solr_server backend_config.connector_config.host {{ hostvars[groups['solr'][0]].ansible_host  }}"
   register: set_search_api_config_host


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1545

# What does this Pull Request do?

Update Search API Solr to 8.x-4.1 (and Solarium to 6.x) while removing patch that no longer applies to Search API Solr 8.x-3.9.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Could affect search, facets etc. but initial tests appear ok.

# How should this be tested?

Is there a baseline set of tests for search on Islandora?

# Additional Notes:
This change is for the playbook but a similar change should happen on the main Islandora project.

# Interested parties
@Islandora-Devops/committers
