### PR TITLE
Fix broken documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ISLANDORA_DISTRO="centos/7" vagrant ssh
 
 ## Use
 
-Detailed installation and usage instructions can be found on the [official installation documentation for Islandora 8](https://islandora.github.io/documentation/installation/).
+Detailed installation and usage instructions can be found on the [official installation documentation for Islandora 8](https://islandora.github.io/documentation/installation/playbook/).
 
 ## Connect
 


### PR DESCRIPTION
**GitHub Issue**: none

# What does this Pull Request do?

Fixes a broken link

# What's new?

https://islandora.github.io/documentation/installation/ has been moved to https://islandora.github.io/documentation/installation/playbook

# How should this be tested?

test links.

# Interested parties
@Islandora-Devops/committers
