### PR TITLE
remove dependency on geerlingguy drupal console ansible role because …

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -40,9 +40,6 @@
 - src: geerlingguy.drush
   version: 3.1.1
 
-- src: geerlingguy.drupal-console
-  version: 1.1.1
-
 - src: https://github.com/Islandora-Devops/ansible-role-activemq
   name: Islandora-Devops.activemq
   version: master

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -107,7 +107,7 @@
     creates: "{{ drupal_external_libraries_directory }}/pdf.js/build"
     remote_src: yes
 
-- name: Add project's /vendor/bin to $PATH
+- name: Add project's /vendor/bin to $PATH (ubuntu)
   lineinfile:
     path: ~/.profile
     line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'
@@ -115,7 +115,7 @@
   become: false
   when: ansible_os_family == "Debian"
 
-- name: 
+- name: Add project's /vendor/bin to $PATH (centos)
   lineinfile:
     path: ~/.bash_profile
     line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -117,7 +117,7 @@
 
 - name: 
   lineinfile:
-    path: ~/bash.profile
+    path: ~/.bash_profile
     line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'
     state: present
   become: false

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -106,3 +106,10 @@
     dest: "{{ drupal_external_libraries_directory }}/pdf.js"
     creates: "{{ drupal_external_libraries_directory }}/pdf.js/build"
     remote_src: yes
+
+- name: Add project's /vendor/bin to $PATH
+  lineinfile:
+    path: ~/.profile
+    line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'
+    state: present
+  become: false

--- a/roles/internal/webserver-app/tasks/drupal.yml
+++ b/roles/internal/webserver-app/tasks/drupal.yml
@@ -113,3 +113,13 @@
     line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'
     state: present
   become: false
+  when: ansible_os_family == "Debian"
+
+- name: 
+  lineinfile:
+    path: ~/bash.profile
+    line: 'PATH="$PATH:{{ webserver_document_root }}/drupal/vendor/bin"'
+    state: present
+  become: false
+  when: ansible_os_family == "RedHat"
+

--- a/webserver.yml
+++ b/webserver.yml
@@ -19,7 +19,6 @@
     - geerlingguy.git
     - geerlingguy.composer
     - geerlingguy.drush
-    - geerlingguy.drupal-console
     - geerlingguy.drupal
     - perms-fix
     - Islandora-Devops.drupal-openseadragon


### PR DESCRIPTION
…composer installs it just fine

**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1599)



# What does this Pull Request do?

Removes dependency on geerlingguy ansible role for drupal console

# What's new?
Depending on composer for installing drupal console


# How should this be tested?
Pull in this PR
run `ISLANDORA_DISTRO="ubuntu/bionic64" vagrant up`
let it build and make sure you have a drupal installation
ssh in `vagrant ssh` and make sure you can run a `drupal` command

# Additional Notes
I didn't test this on centos, so it probably should be

# Interested parties
@Islandora-Devops/committers
