### PR TITLE
drop search_api_solr_defaults

### DIFF
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -43,7 +43,6 @@ drupal_enable_modules:
   - restui
   - devel
   - search_api_solr
-  - search_api_solr_defaults
   - facets
   - content_browser
   - matomo


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1369

See the [islandora_defaults PR](https://github.com/Islandora/islandora_defaults/pull/34#issuecomment-686936354).

# What does this Pull Request do?

Drops the search_api_solr_defaults module from the list of those to enable. We don't need it and it adds another dependency forcing us to keep the comments module around.

# What's new?

Drops the search_api_solr_defaults module from the list of those to enable.

# How should this be tested?

* Apply this PR 
* Follow the testing instructions for https://github.com/Islandora/islandora_defaults/pull/34 (update the islandora_defaults branch to get all the other bits we are removing to purge the comments module)
* See that *only* the article content type is keeping comments enabled.

# Interested parties
@mjordan 