### PR TITLE
Updated the URL for installation docs to a working URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ISLANDORA_DISTRO="centos/7" vagrant ssh
 
 ## Use
 
-Detailed installation and usage instructions can be found on the [official installation documentation for Islandora 8](https://islandora.github.io/documentation/installation/).
+Detailed installation and usage instructions can be found on the [official installation documentation for Islandora 8](https://islandora.github.io/documentation/installation/component_overview).
 
 ## Connect
 
@@ -39,18 +39,18 @@ You can connect to the machine via the browser at [http://localhost:8000](http:/
 ### Drupal
 
 The default Drupal login details are:
-  
+
   * username: admin
   * password: islandora
 
 ### MySQL
-  
+
   * username: drupal8
   * password: islandora
 
 ### Fedora5
 
-The Fedora 5 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest). 
+The Fedora 5 REST API can be accessed at [http://localhost:8080/fcrepo/rest](http://localhost:8080/fcrepo/rest).
 
 Authentication is done via [Syn](https://github.com/Islandora-CLAW/Syn) using [JWT](https://jwt.io) tokens.
 
@@ -63,11 +63,11 @@ You can access the Solr administration UI at http://localhost:8983/solr/
 You can connect to the machine via ssh:
 
   * `vagrant ssh`
-  
+
 ### ActiveMQ
 
 The default ActiveMQ login details are:
-  
+
   * username: admin
   * password: admin
 
@@ -79,17 +79,17 @@ You can access the Cantaloupe admin interface at: http://localhost:8080/cantalou
 
   * username: admin
   * password: islandora
-  
+
 You can access the IIIF interface at: http://localhost:8080/cantaloupe/iiif/2/
 
 ### JWT
 
-Islandora 8 uses JWT for authentication across the stack. Crayfish microservices, Fedora, and Drupal all use them. 
+Islandora 8 uses JWT for authentication across the stack. Crayfish microservices, Fedora, and Drupal all use them.
 Crayfish and Fedora have been set up to use a master token of `islandora` to make testing easier. To use it, just set
 the following header in HTTP requests:
 
   * `Authorization: Bearer islandora`
-  
+
 ### BlazeGraph (Bigdata)
 
 You can access the BlazeGraph interface at: http://localhost:8080/bigdata/
@@ -106,12 +106,11 @@ Islandora 8 Playbook installs an instance of the [Matomo](https://matomo.org/) (
 
   * username: admin
   * password: islandora
- 
+
 ## Roadmap
 
-Our highest priority moving forward is testing installation on different network topologies (e.g. 2, 3, 4 server setups, etc...) 
- 
+Our highest priority moving forward is testing installation on different network topologies (e.g. 2, 3, 4 server setups, etc...)
+
 ## Maintainers
 
 * [Jonathan Green](https://github.com/jonathangreen)
-


### PR DESCRIPTION
**GitHub Issue**: (link)
[Documentation: islandora-playbook README link for installation docs is currently broken](https://github.com/Islandora/documentation/issues/1616)

#1616 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

The islandora-playbook README link for installation docs is currently broken, this commit uses a working URL.

# What's new?

old URL:
https://islandora.github.io/documentation/installation

new URL:

https://islandora.github.io/documentation/installation/component_overview/

# How should this be tested?

Click on link.

# Additional Notes:

# Interested parties

@Islandora-Devops/committers